### PR TITLE
Adding Recursion Logic for Dashboard generation

### DIFF
--- a/src/components/dashboard/dashboardItem/index.tsx
+++ b/src/components/dashboard/dashboardItem/index.tsx
@@ -9,21 +9,32 @@ interface Props {
 }
 
 export class DashboardItem extends React.Component<Props> {
+
+    createDashboardItems() {
+      const dashboardItems = [];
+      let key = 0;
+      for(let child of (this.props.contents as SectionNodeModel).children) {
+        dashboardItems.push(<DashboardItem key={key} contents={child} widgets={this.props.widgets} />)
+        key += 1;
+      }
+      return dashboardItems;
+    }
+
     render() {
+        // This is the case that we hit a Leaf Node (Widget)
         if (this.props.contents.type === 'WidgetModel') {
             return (
                 <Widget key='1' index={1} widget={this.props.widgets[(this.props.contents as WidgetModel).widgetType]} />
             );
         }
+        // This is handling the case that we're not at a Leaf node
+        // We're at a Section, and a Section can be composed of more Sections
+        // or Leafs (Widgets)
+        // We have a recursive style to this
         else if (this.props.contents.type === 'SectionModel') {
             return (
                 <Section>
-                    {
-                        <DashboardItem contents={(this.props.contents as SectionNodeModel).children[0]} widgets={this.props.widgets} />
-                        // (this.props.contents as SectionNodeModel).children.map((child, index) => {
-                        //     <DashboardItem key={index} contents={child} widgets={this.props.widgets} />
-                        // })
-                    }
+                  {this.createDashboardItems()}
                 </Section>
             )
         }

--- a/src/components/widget/index.tsx
+++ b/src/components/widget/index.tsx
@@ -16,7 +16,6 @@ class Widget extends React.Component<WidgetProps> {
   constructor(WidgetProps) {
     super(WidgetProps);
     this.state = React.createRef<Widget>();
-    // console.log(this.state);
   }
 
   generateWidget() {
@@ -35,7 +34,6 @@ class Widget extends React.Component<WidgetProps> {
     // console.log(this);
     // const position = ReactDOM?.findDOMNode(this.forwardRef['UniqueElementIdentifier']).getBoundingClientRect(); //outputs <h3> coordinates
     // console.log(ReactDOM?.findDOMNode(this.props.forwardRef === 'UniqueElementIdentifier')));
-    console.log(this.props.index)
     // return (
     //   <div ref={this.refCallback}>
     //     <Draggable draggableId={"widget"+this.props.index} index={this.props.index}>


### PR DESCRIPTION
Generating Widgets/Sections from the store. 

- We have a redux structure of the form:
```
const Root : RootNodeModel = {
  children: [
    {
      children: [
        {
          widgetType: 'Clock',
          options: null,
          version: 1.0,
          type: 'WidgetModel',
        } as WidgetModel,
        {
          widgetType: 'Clock',
          options: null,
          version: 1.0,
          type: 'WidgetModel',
        } as WidgetModel,
      ],
      sectionDivision: 'HORIZONTAL',
      relativeSize: [0.5, 0.5],
      type: 'SectionModel',
    } as SectionNodeModel,
   ],
  type: 'RootNode',
}
```

What this PR does: 
-Starts from the top level and creates a Dashboard 
-Dashboard creates a DashboardItem component
- Dashboard Item checks current contents type:
      - If Widget type: Create the Widget 
      - If Section type: Create a Section with a DashboardItem for each child 
- Repeat the above until all widgets are rendered (hit all leaf nodes)

In the given example, it will recurse 3 times 
```
              Dashboard 
              /               
        Section
     /              \
Widget     Widget
```

What this looks like:
![Screen Shot 2019-07-09 at 5 25 27 PM](https://user-images.githubusercontent.com/13502814/60924218-a0d61e00-a26e-11e9-9c3f-d93e9d394411.png)


**Future Fixes/Considerations:** 
- We currently pass widgets in as this.props.widgets to each Dashboard component. 
(Probably want to switch this to some shared global object.) 
- Currently setting key using key+=1 and not really a fan of this.

