### PR TITLE
Add Sectioning Logic and Sample Hack the North layout

### DIFF
--- a/src/components/dashboard/dashboardItem/index.tsx
+++ b/src/components/dashboard/dashboardItem/index.tsx
@@ -3,6 +3,7 @@ import { NodeModel, WidgetModel, SectionNodeModel } from "../../../interfaces/no
 import Widget from "../../../components/widget";
 import Section from "../section";
 import uuid4 from 'uuid4';
+import styles from "./dashboardItem.module.css"
 
 interface Props {
     contents: NodeModel;

--- a/src/components/dashboard/section/index.tsx
+++ b/src/components/dashboard/section/index.tsx
@@ -9,9 +9,32 @@ interface Props {
 
 export class Section extends React.Component<Props> {
   render() {
+    const children = this.props.children
+    const relativeSize = this.props.relativeSize
     return (
       <div className={`${styles.section} ${this.props.sectionDivision === 'HORIZONTAL' ? styles.sectionHorizontal : styles.sectionVertical} `}>
-        {this.props.children}
+        {React.Children.map(children, (child, i) => {
+          // Generate a random colour
+          let colour = [];
+          for (var j = 0; j < 3; j++) {
+            colour.push(Math.floor(Math.random()*256));
+          }
+          return (
+            <div style={{
+              backgroundColor: `rgb(${colour[0]}, ${colour[1]}, ${colour[2]})`,
+              // Sizing logic
+              flexBasis: `${relativeSize[i]*100}%`,
+              // When the section is divided horizontally
+              // height is constrained, but width takes up 100% of available space
+              // vice versa for the vertical case
+              width: this.props.sectionDivision == 'HORIZONTAL' ? '100%' : `${relativeSize[i]*100}%`,
+              height: this.props.sectionDivision == 'VERTICAL' ? '100%' : `${relativeSize[i]*100}%`,
+              overflow: 'hidden',
+            }}>
+              {child}
+            </div>
+          )
+        })}
       </div>
     );
   }

--- a/src/components/dashboard/section/section.module.css
+++ b/src/components/dashboard/section/section.module.css
@@ -2,12 +2,16 @@
   display: flex;
   height: 100%;
   width: 100%;
+  color: #635554;
+  background-color: #635554;
+  opacity: 0.9;
+  border: 1px solid #635554;
 }
 
 .sectionHorizontal {
-  flex-direction: row;
+  flex-direction: column;
 }
 
 .sectionVertical {
-  flex-direction: column;
+  flex-direction: row;
 }

--- a/src/components/dashboard/section/section.module.css
+++ b/src/components/dashboard/section/section.module.css
@@ -1,5 +1,7 @@
 .section {
   display: flex;
+  flex-wrap: nowrap;
+  align-items: stretch;
   height: 100%;
   width: 100%;
   color: #635554;

--- a/src/reducers/dashboardReducer.ts
+++ b/src/reducers/dashboardReducer.ts
@@ -40,7 +40,7 @@ const Root : RootNodeModel = {
         {
           // Right side of dashboard
           sectionDivision: 'HORIZONTAL',
-          relativeSize: [0.15, 0.35, 0.45, 0.05],
+          relativeSize: [0.20, 0.30, 0.4, 0.10],
           type: 'SectionModel',
           children: [
             {
@@ -63,8 +63,8 @@ const Root : RootNodeModel = {
                       type: 'WidgetModel',
                     } as WidgetModel,
                     {
-                      // Weather
-                      widgetType: 'ExampleComponent',
+                      // Time
+                      widgetType: 'Clock',
                       options: null,
                       version: 1.0,
                       type: 'WidgetModel',
@@ -78,8 +78,8 @@ const Root : RootNodeModel = {
                   type: 'SectionModel',
                   children: [
                     {
-                      // Time
-                      widgetType: 'Clock',
+                      // Weather
+                      widgetType: 'ExampleComponent',
                       options: null,
                       version: 1.0,
                       type: 'WidgetModel',

--- a/src/reducers/dashboardReducer.ts
+++ b/src/reducers/dashboardReducer.ts
@@ -22,12 +22,14 @@ const Root : RootNodeModel = {
           type: 'SectionModel',
           children: [
             {
+              // Live Feed
               widgetType: 'IFrameComponent',
               options: null,
               version: 1.0,
               type: 'WidgetModel',
             } as WidgetModel,
             {
+              // Schedule
               widgetType: 'ScrollingText',
               options: null,
               version: 1.0,
@@ -48,9 +50,57 @@ const Root : RootNodeModel = {
               type: 'SectionModel',
               children: [
                 {
-                }
+                  // Top row of top infobar
+                  sectionDivision: 'HORIZONTAL',
+                  relativeSize: [0.5, 0.5],
+                  type: 'SectionModel',
+                  children: [
+                    {
+                      // Hack the North Logo
+                      widgetType: 'HelloWorld',
+                      options: null,
+                      version: 1.0,
+                      type: 'WidgetModel',
+                    } as WidgetModel,
+                    {
+                      // Weather
+                      widgetType: 'ExampleComponent',
+                      options: null,
+                      version: 1.0,
+                      type: 'WidgetModel',
+                    } as WidgetModel,
+                  ],
+                } as SectionNodeModel,
+                {
+                  // Bottom row of top infobar
+                  sectionDivision: 'HORIZONTAL',
+                  relativeSize: [0.5, 0.5],
+                  type: 'SectionModel',
+                  children: [
+                    {
+                      // Time
+                      widgetType: 'Clock',
+                      options: null,
+                      version: 1.0,
+                      type: 'WidgetModel',
+                    } as WidgetModel,
+                    {
+                      // Countdown
+                      widgetType: 'Countdown',
+                      options: null,
+                      version: 1.0,
+                      type: 'WidgetModel',
+                    } as WidgetModel,
+                  ],
+                } as SectionNodeModel,
               ],
             } as SectionNodeModel,
+            {
+              widgetType: 'ExampleComponent',
+              options: null,
+              version: 1.0,
+              type: 'WidgetModel',
+            } as WidgetModel,
             {
               widgetType: 'HelloWorld',
               options: null,

--- a/src/reducers/dashboardReducer.ts
+++ b/src/reducers/dashboardReducer.ts
@@ -8,30 +8,66 @@ import {
 } from '../actions/dashboardActions';
 
 const Root : RootNodeModel = {
+  type: 'RootNode',
   children: [
     {
-      children: [
-        {
-          widgetType: 'Clock',
-          id: uuid4(),
-          options: null,
-          version: 1.0,
-          type: 'WidgetModel',
-        } as WidgetModel,
-        {
-          widgetType: 'Clock',
-          id: uuid4(),
-          options: null,
-          version: 1.0,
-          type: 'WidgetModel',
-        } as WidgetModel,
-      ],
       sectionDivision: 'VERTICAL',
       relativeSize: [0.5, 0.5],
       type: 'SectionModel',
+      children: [
+        {
+          // Left side of dashboard
+          sectionDivision: 'HORIZONTAL',
+          relativeSize: [0.5, 0.5],
+          type: 'SectionModel',
+          children: [
+            {
+              widgetType: 'IFrameComponent',
+              options: null,
+              version: 1.0,
+              type: 'WidgetModel',
+            } as WidgetModel,
+            {
+              widgetType: 'ScrollingText',
+              options: null,
+              version: 1.0,
+              type: 'WidgetModel',
+            } as WidgetModel,
+          ],
+        } as SectionNodeModel,
+        {
+          // Right side of dashboard
+          sectionDivision: 'HORIZONTAL',
+          relativeSize: [0.15, 0.35, 0.45, 0.05],
+          type: 'SectionModel',
+          children: [
+            {
+              // Top infobar
+              sectionDivision: 'VERTICAL',
+              relativeSize: [0.5, 0.5],
+              type: 'SectionModel',
+              children: [
+                {
+                }
+              ],
+            } as SectionNodeModel,
+            {
+              widgetType: 'HelloWorld',
+              options: null,
+              version: 1.0,
+              type: 'WidgetModel',
+            } as WidgetModel,
+            {
+              widgetType: 'ScrollingText',
+              options: null,
+              version: 1.0,
+              type: 'WidgetModel',
+            } as WidgetModel,
+          ],
+        } as SectionNodeModel,
+      ],
     } as SectionNodeModel,
    ],
-  type: 'RootNode',
 }
 
 const initialState: DashboardModel = {


### PR DESCRIPTION
This PR accomplishes the following:
- Adds sectioning logic to the section component
- Adds a sample Hack the North state (layout is correct but widgets are based off existing widget list)