### PR TITLE
Add initial undo/redo functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6902,9 +6902,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "immer": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
-      "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.3.tgz",
+      "integrity": "sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -7694,14 +7694,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "optional": true
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7716,20 +7714,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "optional": true
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "optional": true
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "optional": true
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7846,8 +7841,7 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "optional": true
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "ini": {
               "version": "1.3.5",
@@ -7859,7 +7853,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7874,7 +7867,6 @@
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7882,14 +7874,12 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "optional": true
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7908,7 +7898,6 @@
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7989,8 +7978,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "optional": true
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8002,7 +7990,6 @@
               "version": "1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8124,7 +8111,6 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11330,6 +11316,11 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        },
+        "immer": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
+          "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
         },
         "inquirer": {
           "version": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "core-js": "^3.0.1",
     "core-js-compat": "^3.0.1",
     "cross-fetch": "^3.0.2",
+    "immer": "^3.1.3",
     "query-string": "^6.7.0",
     "react": "^16.8.6",
     "react-beautiful-dnd": "^11.0.3",

--- a/src/actions/dashboardActions.ts
+++ b/src/actions/dashboardActions.ts
@@ -35,6 +35,8 @@ export const ADD_WIDGET = "ADD_WIDGET";
 export const REMOVE_WIDGET = "REMOVE_WIDGET";
 export const EDIT_WIDGET = "EDIT_WIDGET"
 export const MOVE_WIDGET = "MOVE_WIDGET"
+export const UNDO = "UNDO";
+export const REDO = "REDO";
 
 export function fetchingDashboard() {
   return {
@@ -181,5 +183,17 @@ export function editWidget(options: any, widgetId: string) {
     type: EDIT_WIDGET,
     widgetId: widgetId,
     options: options,
+  }
+}
+
+function undo() {
+  return {
+    type: UNDO,
+  }
+}
+
+function redo() {
+  return {
+    type: REDO,
   }
 }

--- a/src/components/widget/widget.module.css
+++ b/src/components/widget/widget.module.css
@@ -4,6 +4,7 @@
   padding: 10px;
   margin: 2.5px;
   box-sizing: border-box;
+  transition: height 0.1s ease, width 0.1s ease;
 }
 
 .optionsButton {

--- a/src/interfaces/dashboardModel.ts
+++ b/src/interfaces/dashboardModel.ts
@@ -1,4 +1,4 @@
-import { RootNodeModel, SectionNodeModel, NodeModel } from './nodeModels';
+import { RootNodeModel, SectionNodeModel, NodeModel, WidgetModel } from './nodeModels';
 
 export interface DashboardContentsModel {
   rootSection: string;
@@ -6,7 +6,12 @@ export interface DashboardContentsModel {
     [key: string] : SectionNodeModel;
   }
   widgets: {
-    [key: string] : NodeModel;
+    [key: string] : WidgetModel;
+  }
+  timeline?: {        // Used for undo/redo
+    past: any;        // Holds patches to reverse changes
+    future: any;      // Holds patches to apply changes
+    index: number;    // Holds the index of the current patch
   }
 }
 
@@ -17,7 +22,6 @@ export interface DashboardModel {
   lastSaved: number;
   public: boolean;
   url: String;
-  contentHistory?: String[];
   isFetching?: boolean;
   isSaving?: boolean;
   unsavedChanges?: boolean;

--- a/src/reducers/dashboardReducer.ts
+++ b/src/reducers/dashboardReducer.ts
@@ -1,11 +1,11 @@
-import { DashboardModel } from '../interfaces/dashboardModel';
-import uuid4 from 'uuid4';
+import { DashboardModel, DashboardContentsModel } from '../interfaces/dashboardModel';
 import {
   addWidgetToState,
   removeWidgetFromState,
   moveWidget
 } from '../utils/dashboardModelUtils';
 import { SectionNodeModel, WidgetModel } from '../interfaces/nodeModels';
+import produce, { applyPatches } from "immer";
 
 import {
   FETCHING_DASHBOARD,
@@ -14,6 +14,8 @@ import {
   REMOVE_WIDGET,
   EDIT_WIDGET,
   MOVE_WIDGET,
+  UNDO,
+  REDO
 } from '../actions/dashboardActions';
 
 const widgets = {
@@ -160,11 +162,15 @@ const sections = {
 const initialState: DashboardModel = {
   id: -1,
   name: '',
-  contentHistory: [],
   contents: {
     rootSection: 'root',
     sections: sections,
     widgets: widgets,
+    timeline: {
+      past: [],
+      future: [],
+      index: -1,
+    },
   },
   createdAt: 0,
   isFetching: false,
@@ -175,64 +181,104 @@ const initialState: DashboardModel = {
   url: ''
 }
 
-export function dashboardReducer(
-  state = initialState,
-  action: any
- ): DashboardModel {
-  switch(action.type) {
-    case FETCHING_DASHBOARD:
-      return {
-        ...state,
-        isFetching: true,
-      }
-    case SET_DASHBOARD:
-      return {
-        ...state,
-        ...action.payload.contents,
-        isFetching: false,
-      }
-    case ADD_WIDGET:
-      return {
-        ...state,
-        contents: addWidgetToState(
-          state.contents,
-          action.widgetId,
-          action.parentId,
-          action.index,
-        )
-      }
-    case REMOVE_WIDGET:
-      return {
-        ...state,
-        contents: removeWidgetFromState(state.contents, action.widgetId),
-      }
-    case MOVE_WIDGET:
-      return {
-        ...state,
-        contents: moveWidget(
-          state.contents,
+const contentsReducer = (state, action) => {
+  if (action.type == UNDO) {
+    // Restore an old state only if there are states left to restore
+    // Decrement index, use this to keep track of which state you are at
+    if (state.timeline.index >= 0) {
+      let nextState = applyPatches(state, state.timeline.past[state.timeline.index])
+      return produce<DashboardContentsModel>(nextState, draft => {
+        draft.timeline.index--;
+      })
+    }
+  }
+
+  if (action.type == REDO) {
+    // Re-do a state that has been previously undone
+    // Only if there are states to be done
+    if (state.timeline.index < state.timeline.future.length - 1) {
+      let nextState = applyPatches(state, state.timeline.future[state.timeline.index + 1])
+      return produce<DashboardContentsModel>(nextState, draft => {
+        draft.timeline.index++;
+      })
+    }
+  }
+
+  // The following is any other Dashbaord Contents action (which is undoable)
+  // Here we're using Immer to magically make our state immutable
+  // Immer also has an amazing feature that allows us to create patches for our state changes
+  // This means that given an original state A and modifications are made to make state B
+  // Immer can create patches which describe how A was changed to B and the other way around
+  // We'll store all of these patches, that way we can re-play these patches which becomes our undo/redo
+  // IMPORTANT: make sure you are not re-defining the immer state object
+  // Only mutate it directly or return a new object
+  // E.g. don't do this: draft = abc do this instead: return abc
+  // Learn more here: https://github.com/immerjs/immer
+  let patch = null;   // Will store our A -> B patch
+  let undo = null;    // Will store our reverse B -> A patch
+
+  let nextState = produce<DashboardContentsModel>(state, draft => {
+    switch (action.type) {
+      case SET_DASHBOARD:
+        return action.contents;
+      case ADD_WIDGET:
+        return addWidgetToState(draft, action.widgetId, action.parentId, action.index);
+      case REMOVE_WIDGET:
+        return removeWidgetFromState(draft, action.widgetId);
+      case MOVE_WIDGET:
+        return moveWidget(
+          draft,
           action.sourceIndex,
           action.sourceContainerId,
           action.destinationIndex,
           action.destinationContainerId,
           action.widgetId,
-        ),
-      }
-    case EDIT_WIDGET:
-      return {
-        ...state,
-        contents: {
-          ...state.contents,
-          widgets: {
-            ...state.contents.widgets,
-            [action.widgetId]: {
-              ...state.contents.widgets[action.widgetId],
-              options: action.options,
-            }
-          }
-        }
-      }
-    default:
-      return state
+        );
+      case EDIT_WIDGET:
+        draft.widgets[action.widgetId].options = action.options;
+        return;
+    }
+  },
+  (patches, inversePatches) => {
+    // Storing these patches into variables defined above
+    undo = inversePatches;
+    patch = patches
+  })
+
+  // When we tell immer to create patches for us, immer won't apply the new state immediately
+  // We solve this by applying the new patch that was just created, because we want this applied to our state
+  nextState = applyPatches(state, patch);
+
+  // Only if the state change resulted in something undoable or redoable
+  if (!((undo === undefined || undo.length == 0) && (patch === undefined || patch.length == 0))) {
+    // If we're in the middle of a undo/redo stack, let's throw away everything ahead of it
+    // This is for the case where: something -> something -> undo -> something
+    // For above, you shouldn't be able to redo because it makes no sense
+    // We're also adding the inverse and forward patch into our history
+    nextState = produce<DashboardContentsModel>(nextState, draft => {
+      draft.timeline.past.splice(draft.timeline.index + 1)
+      draft.timeline.future.splice(draft.timeline.index + 1)
+      draft.timeline.past.push(undo);
+      draft.timeline.future.push(patch);
+      draft.timeline.index = draft.timeline.past.length - 1;
+    })
   }
+
+  return nextState;
+}
+
+// Here we're using a nested reducer (contents reducer above and nested here)
+export const dashboardReducer = (state = initialState, action) => {
+  return produce<DashboardModel>(state, draft => {
+    switch (action.type) {
+      case FETCHING_DASHBOARD:
+        draft.isFetching = true;
+        break;
+      case SET_DASHBOARD:
+        draft.isFetching = false;
+        break;
+    }
+    draft.contents = contentsReducer(state.contents, action)
+    return;
+  })
 }

--- a/src/utils/dashboardModelUtils.ts
+++ b/src/utils/dashboardModelUtils.ts
@@ -40,6 +40,9 @@ export function moveWidget(
   destinationContainerId: string,
   widgetId: string
 ) {
+  // TODO: There's no need to redistribute sizing if it's the same container
+  // E.g. moving something in the same section shouldn't resize it
+  // Noting this down to maybe fix in the future
   removeChildAndReDistributeSizing(contents.sections, sourceContainerId, widgetId)
   addWidgetToState(contents, destinationContainerId, widgetId, destinationIndex)
 


### PR DESCRIPTION
woooo boi

probably should've created multiple commits but didn't think that far ahead

This PR does the following:
- Adds immer (which helps us keep our states immutable (yay!) and is the foundation for our undo/redo functionality
- Creates actions for undo and redo
- Adds a transition for drag and drop just so it's pettier
- Changes our data model to include a new timeline object, used for drag and drop
- Restructures the dashboardReducer to use immer
- Nest a new dashboardContents reducer into dashboard reducer
- Restructure dashboardReducer to handle undo/redo actions
- Update the dashboard utils to now use the magical powers of immer so we don't have to create new objects (we can just modify the contents directly)

yayy!